### PR TITLE
fix: Slack Webhook URL

### DIFF
--- a/.gf/slack-webhook.json
+++ b/.gf/slack-webhook.json
@@ -1,4 +1,4 @@
 {
     "flags": "-Prohi",
-    "pattern": "https://hooks\\.slack\\.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}"
+    "pattern": "https://hooks\\.slack\\.com/services/T[a-zA-Z0-9_]{10}/B[a-zA-Z0-9_]{10}/[a-zA-Z0-9_]{24}"
 }

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ xox[baprs]-([0-9a-zA-Z]{10,48})?
 
 ### Slack Webhook
 ```
-https://hooks.slack.com/services/T[a-zA-Z0-9_]{8}/B[a-zA-Z0-9_]{8}/[a-zA-Z0-9_]{24}
+https://hooks.slack.com/services/T[a-zA-Z0-9_]{10}/B[a-zA-Z0-9_]{10}/[a-zA-Z0-9_]{24}
 ```
 
 ### Stripe API Key
@@ -297,7 +297,7 @@ With HTTP Protocol:
 ```
 https?:\/\/(www\.)?[-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)
 ```
-Without Protocol: 
+Without Protocol:
 ```
 [-a-zA-Z0-9@:%._\+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_\+.~#?&//=]*)
 ```


### PR DESCRIPTION
I created a Slack Webhook URL using the [Incoming Webhooks App](https://slack.com/apps/A0F7XDUAZ-incoming-webhooks?tab=more_info) and the RegEx failed. 

Changing the `8` to `10` makes the RegEx pass. You may confirm by creating a dummy Slack Webhook URL.