### PR TITLE
Update stripe-key to add support for restricted keys and longer keys

### DIFF
--- a/.gf/stripe-key.json
+++ b/.gf/stripe-key.json
@@ -1,4 +1,4 @@
 {
     "flags": "-Prohi",
-    "pattern": "(?:r|s)k_live_[0-9a-zA-Z]{24}"
+    "pattern": "(pk|sk|rk)_(test|live)_[A-Za-z0-9]+"
 }

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ https://hooks.slack.com/services/T[a-zA-Z0-9_]{10}/B[a-zA-Z0-9_]{10}/[a-zA-Z0-9_
 
 ### Stripe API Key
 ```
-(?:r|s)k_live_[0-9a-zA-Z]{24}
+(pk|sk|rk)_(test|live)_[A-Za-z0-9]+
 ```
 
 ### Square Access Token


### PR DESCRIPTION
See:
- https://stripe.com/docs/keys
- https://support.stripe.com/questions/new-api-keys-are-longer-than-existing-keys